### PR TITLE
todo proc type should indicate gcsafe

### DIFF
--- a/testground_sdk.nim
+++ b/testground_sdk.nim
@@ -220,7 +220,7 @@ proc param*[T](c: Client, _: type[T], name: string): T =
   else:
     {.error: "Unsupported type for param".}
 
-proc runner(todo: proc(c: Client): Future[void]) {.async.} =
+proc runner(todo: proc(c: Client): Future[void] {.gcsafe.}) {.async.} =
   let
     c = Client(
       testRun: getEnv("TEST_RUN"),


### PR DESCRIPTION
When compiling with `--threads:on` if `{.gcsafe.}` is not indicated for `todo: proc(c: Client): Future[void]` then compilation will fail with *"Error: 'runner' is not GC-safe as it performs an indirect call via 'todo'"*.

See the logic in `proc trackProc` of `compiler/sempass2.nim`:
https://github.com/nim-lang/Nim/blob/v1.6.6/compiler/sempass2.nim#L1394