### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/example_test.yml
+++ b/.github/workflows/example_test.yml
@@ -21,5 +21,5 @@ jobs:
 
       - name: Run the plan
         env:
-          SdkGitRef: ${GITHUB_SHA}
+          SdkGitRef: ${{ github.GITHUB_SHA }}
         run: testground build composition -f examples/simple_tcp_ping/simple_composition.toml --wait

--- a/.github/workflows/example_test.yml
+++ b/.github/workflows/example_test.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+
+name: test example
+
+jobs:
+  run-example-test-plans:
+    name: "Run example plan"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Setup testground
+        uses: "libp2p/test-plans/.github/actions/setup-testground@master"
+
+      - uses: actions/checkout@v2
+
+      - name: Import the plan
+        run: testground plan import --from examples --name examples
+
+      - name: Run the plan
+        env:
+          SdkGitRef: ${GITHUB_SHA}
+        run: testground run single --plan=examples/simple_tcp_ping --testcase=simple_tcp_ping --runner=local:docker --builder=docker:generic --instances=2 --wait

--- a/.github/workflows/example_test.yml
+++ b/.github/workflows/example_test.yml
@@ -17,9 +17,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Import the plan
-        run: testground plan import --from examples --name examples
+        run: testground plan import --name simple_tcp_ping --from examples/simple_tcp_ping
 
       - name: Run the plan
         env:
           SdkGitRef: ${GITHUB_SHA}
-        run: testground run single --plan=examples/simple_tcp_ping --testcase=simple_tcp_ping --runner=local:docker --builder=docker:generic --instances=2 --wait
+        run: testground build composition -f examples/simple_tcp_ping/simple_composition.toml --wait

--- a/.github/workflows/example_test.yml
+++ b/.github/workflows/example_test.yml
@@ -19,7 +19,12 @@ jobs:
       - name: Import the plan
         run: testground plan import --name simple_tcp_ping --from examples/simple_tcp_ping
 
-      - name: Run the plan
+      - name: Build the composition
         env:
           SdkGitRef: ${{ github.GITHUB_SHA }}
         run: testground build composition -f examples/simple_tcp_ping/simple_composition.toml --wait
+
+      - name: Run the composition
+        env:
+          SdkGitRef: ${{ github.GITHUB_SHA }}
+        run: testground run composition -f examples/simple_tcp_ping/simple_composition.toml --wait

--- a/examples/simple_tcp_ping/Dockerfile
+++ b/examples/simple_tcp_ping/Dockerfile
@@ -3,6 +3,7 @@ FROM nimlang/nim:alpine as builder
 # "checkpoint" to avoid installing dependencies every time
 # this is optional
 ARG SDK_GIT_REF="master"
+RUN echo "e ${SDK_GIT_REF}"
 RUN nimble install -y "https://github.com/status-im/testground-nim-sdk@#${SDK_GIT_REF}"
 FROM builder
 

--- a/examples/simple_tcp_ping/Dockerfile
+++ b/examples/simple_tcp_ping/Dockerfile
@@ -3,7 +3,6 @@ FROM nimlang/nim:alpine as builder
 # "checkpoint" to avoid installing dependencies every time
 # this is optional
 ARG SDK_GIT_REF="master"
-RUN echo "e ${SDK_GIT_REF}"
 RUN nimble install -y "https://github.com/status-im/testground-nim-sdk@#${SDK_GIT_REF}"
 FROM builder
 

--- a/examples/simple_tcp_ping/Dockerfile
+++ b/examples/simple_tcp_ping/Dockerfile
@@ -2,7 +2,8 @@ FROM nimlang/nim:alpine as builder
 
 # "checkpoint" to avoid installing dependencies every time
 # this is optional
-RUN nimble install -y "https://github.com/status-im/testground-nim-sdk"
+ARG SDK_GIT_REF="master"
+RUN nimble install -y "https://github.com/status-im/testground-nim-sdk@#${SDK_GIT_REF}"
 FROM builder
 
 COPY . .

--- a/examples/simple_tcp_ping/manifest.toml
+++ b/examples/simple_tcp_ping/manifest.toml
@@ -6,9 +6,6 @@ runner = "local:docker"
 [builders."docker:generic"]
 enabled = true
 
-[builders."docker:generic".build_args]
-SDK_GIT_REF = """{{ or $.Env.SdkGitRef "master"}}"""
-
 [runners."local:docker"]
 enabled = true
 

--- a/examples/simple_tcp_ping/manifest.toml
+++ b/examples/simple_tcp_ping/manifest.toml
@@ -6,6 +6,9 @@ runner = "local:docker"
 [builders."docker:generic"]
 enabled = true
 
+[builders."docker:generic".build_args]
+SDK_GIT_REF = """{{ or $.Env.SdkGitRef "master"}}"""
+
 [runners."local:docker"]
 enabled = true
 

--- a/examples/simple_tcp_ping/simple_composition.toml
+++ b/examples/simple_tcp_ping/simple_composition.toml
@@ -1,0 +1,28 @@
+[metadata]
+  name = 'simple_tcp_ping'
+  author = ""
+
+[global]
+  plan = "simple_tcp_ping"
+  case = "simple_tcp_ping"
+  total_instances = 0
+  builder = "docker:generic"
+  runner = "local:docker"
+  disable_metrics = false
+
+[[groups]]
+  id = "a"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = ""
+    cpu = ""
+  [groups.instances]
+    count = 2
+    percentage = 0.0
+  [groups.build_config]
+    enabled = true
+    [groups.build_config.build_args]
+      SDK_GIT_REF = '{{ or $.Env.SdkGitRef "master" }}'
+  [groups.build]
+  [groups.run]
+    artifact = ""


### PR DESCRIPTION
Composition are quite powerful (allow to run multiple versions of the same deps, amongst other things)
Here, we have to use them just to pass the current branch to the Dockerfile

Would be nice to reuse [a more advanced CI workflow](https://github.com/libp2p/test-plans/blob/master/.github/workflows/run-composition.yml), but it's tuned for libp2p. Maybe we can build a generic one